### PR TITLE
feat: add readme-harness agent with SequentialAgent, LoopAgent, and MCP

### DIFF
--- a/python/agents/README.md
+++ b/python/agents/README.md
@@ -61,6 +61,7 @@ Check out the agent samples below, organized by category:
 | [Google Trends Agent](google-trends-agent) | Surfaces top trending search trends from Google Trends using BigQuery dataset. Shows trending topics by region and time period. | BigQuery, Trend analysis, Sequential agent | Conversational | Medium | Sequential Agent | Marketing & Analytics |
 | [Hierarchical Workflow Automation](hierarchical-workflow-automation) | The "Hierarchical Workflow Automation" pattern is an automation process where multiple distinct tasks or transactions must be executed in a structured hierarchy across various systems to complete a full workflow | Multi-agent, Custom tool, BigQuery, Agent Tool | Workflow | Advanced | Multi Agent / Sequential Agent | Order Management / Customer Support |
 | [Plumber-Data-Engineering-Assistant](Plumber-Data-Engineering-Assistant) | A data engineering assistant agent capable of creating and deploy big data pipelines in Apache Spark, Apache Beam and dBT on GCP data stack via conversations | Big Data, Data Analytics, Streaming Analytics, Dataflow, Dataproc, Bigquery | Conversational | Hard | Multi Agent | Data & Analytics |
+| [README Harness](readme-harness) | Fetches a GitHub repo via MCP, generates a README against a quality checklist, and refines in a LoopAgent until a critic approves. Demonstrates SequentialAgent, LoopAgent, McpToolset, SkillToolset, and exit_loop. | SequentialAgent, LoopAgent, McpToolset, SkillToolset, MCP | Workflow | Intermediate | Multi Agent | Horizontal |
 
 
 

--- a/python/agents/readme-harness/.env.example
+++ b/python/agents/readme-harness/.env.example
@@ -1,0 +1,3 @@
+GOOGLE_API_KEY=your-api-key-here
+GOOGLE_GENAI_USE_VERTEXAI=FALSE
+GITHUB_PERSONAL_ACCESS_TOKEN=your-github-token-here

--- a/python/agents/readme-harness/README.md
+++ b/python/agents/readme-harness/README.md
@@ -1,0 +1,178 @@
+# README Improvement Harness with ADK
+
+A harness that fetches a GitHub repo, analyzes the codebase, generates a README against a quality checklist, and refines until a critic approves. Built with ADK's SequentialAgent, LoopAgent, McpToolset, and SkillToolset.
+
+## Architecture
+
+```
+readme_harness (SequentialAgent)
+├── codebase_analyzer (Agent)          → Fetches repo via GitHub MCP
+│   └── tools: [McpToolset]           → output_key: codebase_analysis
+└── refinement_loop (LoopAgent, max_iterations: 3)
+    ├── readme_writer (Agent)          → Generates README using SkillToolset
+    │   └── tools: [SkillToolset]     → output_key: current_readme
+    └── readme_critic (Agent)          → Validates against 9-section checklist
+        └── tools: [exit_loop]        → output_key: criticism
+```
+
+**How it works:**
+
+1. The **analyzer** fetches the repo's file tree, source files, and dependencies via GitHub MCP
+2. The **writer** loads a README conventions skill and generates a draft
+3. The **critic** checks 9 required sections (Title, Installation, Usage, Configuration, API, Contributing, License, Prerequisites, Project Structure)
+4. If any section is missing, the critic provides feedback and the loop continues
+5. When all sections pass, the critic calls `exit_loop` and the harness returns the final README
+
+## Prerequisites
+
+- Python 3.11+
+- [Google ADK](https://google.github.io/adk-docs/) (`pip install google-adk`)
+- A [Google API key](https://aistudio.google.com/apikey)
+- A [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens/new)
+- Node.js/npx (for the GitHub MCP server)
+
+## Quick Start
+
+```bash
+# Clone the repo
+git clone https://github.com/GoogleCloudPlatform/adk-samples.git
+cd adk-samples/python/agents/readme-harness
+
+# Set up environment
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e .
+
+# Configure API keys
+cp .env.example app/.env
+# Edit app/.env with your GOOGLE_API_KEY and GITHUB_PERSONAL_ACCESS_TOKEN
+```
+
+## Three Ways to Run
+
+### 1. ADK Web UI (Interactive)
+
+Run the harness inside ADK's built-in web interface. Best for exploring and debugging.
+
+```bash
+adk web .
+```
+
+Open `http://localhost:8000`, select `app` from the agent dropdown, and type:
+
+> Improve the README for google/adk-samples
+
+You will see each stage execute in real time: analyzer fetching files, writer loading skills, critic providing feedback, and the loop iterating until approval.
+
+### 2. API Server (Programmatic)
+
+Run the harness as a REST API. Other agents, scripts, or services can call it over HTTP.
+
+```bash
+adk api_server . --port 8000
+```
+
+Test with the bundled helper script:
+
+```bash
+python3 app/scripts/call_harness.py google/adk-samples
+```
+
+The script streams color-coded progress to stderr and prints the final README to stdout:
+
+```
+[   STAGE 1] Analyzing codebase via GitHub MCP...
+[     FETCH] google/adk-samples/
+[     FETCH] google/adk-samples/README.md
+[  ANALYSIS] A comprehensive collection of cross-language sample agents...
+[   STAGE 2] Generating README (pass 1)...
+[     SKILL] Loading: readme-conventions
+[     DRAFT] 87 lines generated
+[    REVIEW] Critic reviewing (pass 1)...
+[  FEEDBACK] Configuration section needs additions...
+[    REFINE] Improving README (pass 2)...
+[     DRAFT] 95 lines generated
+[    REVIEW] Critic reviewing (pass 2)...
+[  APPROVED] Critic approved the README!
+```
+
+Save to a file:
+
+```bash
+python3 app/scripts/call_harness.py google/adk-samples --save improved-readme.md
+```
+
+### 3. CLI Tool Integration (Claude Code / Gemini CLI)
+
+Use the harness from your daily coding CLI. Start the API server, copy the bundled skill, and ask naturally.
+
+**Step 1: Start the harness server**
+
+```bash
+adk api_server . --port 8000
+```
+
+**Step 2: Install the CLI skill**
+
+The `cli_harness/` folder is a self-contained skill compatible with both Claude Code and Gemini CLI.
+
+For Claude Code:
+```bash
+cp -r app/cli_harness .claude/skills/cli_harness
+```
+
+For Gemini CLI:
+```bash
+cp -r app/cli_harness ~/.gemini/skills/cli_harness
+```
+
+**Step 3: Use it**
+
+In Claude Code:
+```
+/cli_harness Improve the README for google/adk-samples
+```
+
+In Gemini CLI:
+```
+Use cli_harness to improve the README for google/adk-samples
+```
+
+The CLI tool runs the helper script, which calls the ADK harness over HTTP. The harness does the heavy lifting: fetching the repo via GitHub MCP, generating against conventions, validating against the checklist, and refining until the critic approves. The CLI tool is just the interface.
+
+## Project Structure
+
+```
+readme-harness/
+├── app/
+│   ├── __init__.py
+│   ├── agent.py              # Root agent: SequentialAgent + LoopAgent
+│   ├── skills/
+│   │   └── readme-conventions/
+│   │       ├── SKILL.md              # L2: README writing instructions
+│   │       └── references/
+│   │           └── checklist.md      # L3: 9-section quality checklist
+│   ├── scripts/
+│   │   └── call_harness.py           # Helper script for API server mode
+│   └── cli_harness/
+│       ├── SKILL.md                  # Skill for Claude Code / Gemini CLI
+│       └── scripts/
+│           └── call_harness.py       # Bundled helper script
+├── .env.example
+├── pyproject.toml
+└── README.md
+```
+
+## ADK Primitives Used
+
+| Primitive | Role in Harness | Docs |
+|-----------|----------------|------|
+| `SequentialAgent` | Two-stage pipeline: analyze then refine | [Docs](https://google.github.io/adk-docs/agents/workflow-agents/sequential-agents/) |
+| `LoopAgent` | Iterative refinement: writer + critic cycle | [Docs](https://google.github.io/adk-docs/agents/workflow-agents/loop-agents/) |
+| `McpToolset` | GitHub repo access via MCP | [Docs](https://google.github.io/adk-docs/tools-custom/mcp-tools/) |
+| `SkillToolset` | README conventions loaded on demand | [Docs](https://google.github.io/adk-docs/skills/) |
+| `exit_loop` | Critic signals approval to stop the loop | [Source](https://github.com/google/adk-python/tree/main/src/google/adk/tools/exit_loop_tool.py) |
+| `output_key` | State passing between agents | [Docs](https://google.github.io/adk-docs/sessions/state/) |
+
+## License
+
+Apache 2.0

--- a/python/agents/readme-harness/app/__init__.py
+++ b/python/agents/readme-harness/app/__init__.py
@@ -1,0 +1,1 @@
+from . import agent

--- a/python/agents/readme-harness/app/agent.py
+++ b/python/agents/readme-harness/app/agent.py
@@ -1,0 +1,179 @@
+"""README improvement harness built with ADK.
+
+A SequentialAgent pipeline that fetches a GitHub repo via MCP,
+generates a README using skill-based conventions, and refines
+it in a LoopAgent until a critic approves.
+"""
+
+import os
+import pathlib
+
+from google.adk.agents import Agent, LoopAgent, SequentialAgent
+from google.adk.agents.callback_context import CallbackContext
+from google.adk.skills import load_skill_from_dir
+from google.adk.tools import exit_loop
+from google.adk.tools.mcp_tool import McpToolset
+from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
+from google.adk.tools.skill_toolset import SkillToolset
+from mcp import StdioServerParameters
+
+SKILLS_DIR = pathlib.Path(__file__).parent / "skills"
+
+# --- Tool Group 1: GitHub MCP (fetch repo contents) ---
+
+github_mcp = McpToolset(
+    connection_params=StdioConnectionParams(
+        server_params=StdioServerParameters(
+            command="npx",
+            args=["-y", "@modelcontextprotocol/server-github"],
+            env={
+                "GITHUB_PERSONAL_ACCESS_TOKEN": os.getenv(
+                    "GITHUB_PERSONAL_ACCESS_TOKEN", ""
+                ),
+            },
+        ),
+        timeout=30,
+    ),
+    tool_filter=[
+        "get_file_contents",
+        "search_code",
+        "search_repositories",
+        "list_commits",
+    ],
+)
+
+# --- Tool Group 2: README conventions skill ---
+
+readme_skill = SkillToolset(
+    skills=[load_skill_from_dir(SKILLS_DIR / "readme-conventions")],
+)
+
+# --- Stage 1: Codebase Analyzer ---
+
+codebase_analyzer = Agent(
+    model="gemini-3-flash-preview",
+    name="codebase_analyzer",
+    instruction="""\
+You are a codebase analyst. The user will give you a GitHub repository
+(owner/repo format or a full URL).
+
+Your job:
+1. Use the GitHub MCP tools to explore the repository.
+2. Read the top-level file list and identify key files:
+   - README.md (if it exists)
+   - package.json, pyproject.toml, requirements.txt, or similar
+   - Main source directories (src/, lib/, app/, etc.)
+   - Configuration files (.env.example, Dockerfile, etc.)
+3. Read the main source files (up to 5 key files) to understand
+   what the project does.
+4. Read any existing README.md to understand current coverage.
+
+Output a structured analysis with these sections:
+- **Project purpose**: One sentence on what this project does.
+- **Tech stack**: Languages, frameworks, key dependencies.
+- **Key modules**: Main directories and what they contain.
+- **Setup requirements**: How to install and configure.
+- **API surface**: Main exports, commands, or endpoints.
+- **Existing README gaps**: What the current README misses or gets wrong.
+  If no README exists, say "No README found."
+""",
+    tools=[github_mcp],
+    output_key="codebase_analysis",
+)
+
+# --- Callback: Initialize loop state on first iteration ---
+
+
+async def init_loop_state(callback_context: CallbackContext) -> None:
+    """Set default criticism on first loop pass so {criticism} resolves."""
+    if "criticism" not in callback_context.state:
+        callback_context.state["criticism"] = (
+            "No previous feedback. This is the first draft."
+        )
+
+
+# --- Stage 2a: README Writer ---
+
+readme_writer = Agent(
+    model="gemini-3-flash-preview",
+    name="readme_writer",
+    before_agent_callback=init_loop_state,
+    instruction="""\
+You are a README writer. Your job is to write or improve a README.md
+for the repository described in the codebase analysis below.
+
+**Codebase analysis:**
+{codebase_analysis}
+
+**Previous criticism (if any):**
+{criticism}
+
+Instructions:
+1. Load the readme-conventions skill to learn the required structure.
+2. Load the checklist reference for section-by-section quality criteria.
+3. Write a complete README.md that covers every required section.
+4. If criticism was provided, address every point specifically.
+5. Write from a developer's perspective: assume the reader wants to
+   clone, install, and use this project within 5 minutes.
+
+Output the full README.md content in markdown format.
+""",
+    tools=[readme_skill],
+    output_key="current_readme",
+)
+
+# --- Stage 2b: README Critic ---
+
+readme_critic = Agent(
+    model="gemini-3-flash-preview",
+    name="readme_critic",
+    instruction="""\
+You are a README quality reviewer. Review the README below against
+the required sections checklist.
+
+**README to review:**
+{current_readme}
+
+**Codebase context (for accuracy check):**
+{codebase_analysis}
+
+Check each required section:
+1. **Title and description**: Clear, one-sentence purpose statement?
+2. **Installation**: Step-by-step setup commands that work?
+3. **Usage**: At least one code example or CLI command?
+4. **Configuration**: Environment variables, config files documented?
+5. **API / Key features**: Main capabilities listed?
+6. **Contributing**: How to contribute mentioned?
+7. **License**: License referenced?
+
+Scoring:
+- If ALL sections are present and reasonably complete, call exit_loop.
+- If ANY section is missing or clearly incomplete, list what needs
+  fixing and do NOT call exit_loop.
+
+Be practical, not pedantic. A section with 2-3 sentences is fine.
+A missing section is not.
+""",
+    tools=[exit_loop],
+    output_key="criticism",
+)
+
+# --- Stage 2: Refinement Loop ---
+
+refinement_loop = LoopAgent(
+    name="refinement_loop",
+    sub_agents=[readme_writer, readme_critic],
+    max_iterations=3,
+)
+
+# --- Root Agent: The Harness ---
+
+root_agent = SequentialAgent(
+    name="readme_harness",
+    description=(
+        "A README improvement harness. Give it a GitHub repo and it "
+        "fetches the code, generates a README against a quality checklist, "
+        "and refines until the critic approves."
+    ),
+    sub_agents=[codebase_analyzer, refinement_loop],
+)

--- a/python/agents/readme-harness/app/cli_harness/SKILL.md
+++ b/python/agents/readme-harness/app/cli_harness/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: cli_harness
+description: >
+  Improve any GitHub repo's README using the ADK README harness running
+  on localhost. Fetches code via GitHub MCP, generates against a quality
+  checklist, and refines until a critic approves. Works with Claude Code
+  and Gemini CLI.
+---
+
+# CLI Harness — README Improvement via ADK
+
+## Prerequisites
+
+The ADK README harness must be running as an api_server on port 8000.
+
+To start it:
+```bash
+cd <path-to>/adk-readme-harness
+source code/.venv/bin/activate
+adk api_server . --port 8000
+```
+
+## How to Use
+
+When the user asks to improve a README for a GitHub repo, run the helper script
+bundled with this skill. The script path is relative to this skill's directory.
+
+Find the `call_harness.py` script in this skill's `scripts/` folder and run:
+
+```bash
+python3 <skill-dir>/scripts/call_harness.py <owner/repo>
+```
+
+For example, if this skill is installed at `.claude/skills/cli_harness/`:
+```bash
+python3 .claude/skills/cli_harness/scripts/call_harness.py google/adk-samples
+```
+
+Or if installed globally for Gemini CLI:
+```bash
+python3 ~/.gemini/skills/cli_harness/scripts/call_harness.py google/adk-samples
+```
+
+### Save to file
+```bash
+python3 <skill-dir>/scripts/call_harness.py owner/repo --save improved-readme.md
+```
+
+### Custom host
+```bash
+python3 <skill-dir>/scripts/call_harness.py owner/repo --host http://localhost:9000
+```
+
+## Output
+
+- **stderr**: Color-coded progress showing each harness stage (analyzer, writer, critic, feedback, approval)
+- **stdout**: The final improved README in markdown
+
+## What Happens Behind the Scenes
+
+The script calls an ADK agent harness running as an api_server. The harness is a
+SequentialAgent with two stages:
+
+1. **Codebase Analyzer** — Fetches repo via GitHub MCP (file tree, source, deps, existing README)
+2. **Refinement Loop** — A LoopAgent cycles between:
+   - **Writer** — Generates README using a SkillToolset with conventions checklist
+   - **Critic** — Validates against 9 required sections, calls `exit_loop` when approved
+
+The loop runs up to 3 iterations. You will see the progress streamed in the terminal.
+
+## Trigger Phrases
+
+- "Improve the README for owner/repo"
+- "Generate a better README for this GitHub repo: owner/repo"
+- "Fix the README for owner/repo"
+- "Analyze owner/repo and write a good README"

--- a/python/agents/readme-harness/app/cli_harness/scripts/call_harness.py
+++ b/python/agents/readme-harness/app/cli_harness/scripts/call_harness.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Call the README harness api_server and stream progress.
+
+Usage:
+    python scripts/call_harness.py owner/repo [--host localhost:8000] [--save output.md]
+
+The script:
+1. Creates a session on the running api_server
+2. Sends the repo to the README harness
+3. Streams progress (which agent is running, tool calls, feedback)
+4. Prints the final README to stdout (or saves to file)
+"""
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+
+
+def create_session(base_url: str) -> str:
+    """Create a new session and return its ID."""
+    url = f"{base_url}/apps/app/users/cli_user/sessions"
+    req = urllib.request.Request(
+        url,
+        data=b"{}",
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as resp:
+        data = json.loads(resp.read())
+        return data["id"]
+
+
+def run_harness(base_url: str, session_id: str, repo: str):
+    """Send repo to the harness and stream progress. Returns final README."""
+    url = f"{base_url}/run_sse"
+    payload = json.dumps(
+        {
+            "app_name": "app",
+            "user_id": "cli_user",
+            "session_id": session_id,
+            "new_message": {
+                "role": "user",
+                "parts": [{"text": f"Improve the README for {repo}"}],
+            },
+            "streaming": False,
+        }
+    ).encode()
+
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    final_readme = ""
+    current_agent = ""
+    iteration = 0
+
+    with urllib.request.urlopen(req, timeout=300) as resp:
+        for raw_line in resp:
+            line = raw_line.decode("utf-8").strip()
+            if not line or line.startswith(":"):
+                continue
+            if not line.startswith("data: "):
+                continue
+
+            data = line[6:]
+            try:
+                event = json.loads(data)
+            except json.JSONDecodeError:
+                continue
+
+            content = event.get("content", {})
+            author = content.get("author", event.get("author", ""))
+            parts = content.get("parts", [])
+
+            # Track agent transitions
+            if author and author != current_agent:
+                current_agent = author
+                if author == "codebase_analyzer":
+                    log("STAGE 1", "Analyzing codebase via GitHub MCP...")
+                elif author == "readme_writer":
+                    iteration += 1
+                    if iteration == 1:
+                        log("STAGE 2", "Generating README (pass 1)...")
+                    else:
+                        log("REFINE", f"Improving README (pass {iteration})...")
+                elif author == "readme_critic":
+                    log("REVIEW", f"Critic reviewing (pass {iteration})...")
+
+            for part in parts:
+                if "functionCall" in part:
+                    fc = part["functionCall"]
+                    name = fc["name"]
+                    args = fc.get("args", {})
+
+                    if name == "exit_loop":
+                        log("APPROVED", "Critic approved the README!")
+                    elif name == "get_file_contents":
+                        path = args.get("path", "/")
+                        log(
+                            "  FETCH",
+                            f"{args.get('owner', '')}/{args.get('repo', '')}/{path}",
+                        )
+                    elif name == "search_code":
+                        log("  SEARCH", f"query: {args.get('query', '')[:60]}")
+                    elif name == "load_skill":
+                        log("  SKILL", f"Loading: {args.get('name', '')}")
+                    elif name == "load_skill_resource":
+                        log("  SKILL", f"Reading: {args.get('path', '')}")
+                    else:
+                        log("  TOOL", f"{name}")
+
+                elif "text" in part:
+                    text = part["text"]
+                    if author == "codebase_analyzer":
+                        # Show first line of analysis
+                        first_line = text.strip().split("\n")[0][:120]
+                        log("ANALYSIS", first_line)
+                    elif author == "readme_writer":
+                        # Capture the README output
+                        final_readme = text
+                        lines = text.strip().split("\n")
+                        log("DRAFT", f"{len(lines)} lines generated")
+                    elif author == "readme_critic":
+                        if "exit_loop" not in text.lower() and len(text) > 30:
+                            # Show first line of feedback
+                            first_line = text.strip().split("\n")[0][:120]
+                            log("FEEDBACK", first_line)
+
+    return final_readme
+
+
+def log(tag: str, message: str):
+    """Print a formatted progress line to stderr."""
+    # Color codes for terminal
+    colors = {
+        "STAGE 1": "\033[36m",  # cyan
+        "STAGE 2": "\033[33m",  # yellow
+        "REFINE": "\033[33m",  # yellow
+        "REVIEW": "\033[35m",  # magenta
+        "APPROVED": "\033[32m",  # green
+        "ANALYSIS": "\033[36m",  # cyan
+        "DRAFT": "\033[33m",  # yellow
+        "FEEDBACK": "\033[31m",  # red
+        "  FETCH": "\033[90m",  # gray
+        "  SEARCH": "\033[90m",  # gray
+        "  SKILL": "\033[90m",  # gray
+        "  TOOL": "\033[90m",  # gray
+    }
+    reset = "\033[0m"
+    color = colors.get(tag, "")
+    print(f"{color}[{tag:>10}]{reset} {message}", file=sys.stderr)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Call the README harness")
+    parser.add_argument("repo", help="GitHub repo in owner/repo format")
+    parser.add_argument(
+        "--host", default="http://localhost:8000", help="api_server URL"
+    )
+    parser.add_argument("--save", help="Save README to file instead of stdout")
+    args = parser.parse_args()
+
+    print(f"\033[1m{'=' * 60}\033[0m", file=sys.stderr)
+    print(f"\033[1m README Harness — {args.repo}\033[0m", file=sys.stderr)
+    print(f"\033[1m{'=' * 60}\033[0m", file=sys.stderr)
+
+    try:
+        session_id = create_session(args.host)
+        log("SESSION", f"Created: {session_id[:8]}...")
+    except urllib.error.URLError:
+        print(
+            "ERROR: Cannot connect to api_server. Is it running?",
+            file=sys.stderr,
+        )
+        print("Start it with: adk api_server . --port 8000", file=sys.stderr)
+        sys.exit(1)
+
+    readme = run_harness(args.host, session_id, args.repo)
+
+    print(f"\033[1m{'=' * 60}\033[0m", file=sys.stderr)
+
+    if args.save:
+        with open(args.save, "w") as f:
+            f.write(readme)
+        log("SAVED", f"README written to {args.save}")
+    else:
+        # Print README to stdout (progress went to stderr)
+        print(readme)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/agents/readme-harness/app/scripts/call_harness.py
+++ b/python/agents/readme-harness/app/scripts/call_harness.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Call the README harness api_server and stream progress.
+
+Usage:
+    python scripts/call_harness.py owner/repo [--host localhost:8000] [--save output.md]
+
+The script:
+1. Creates a session on the running api_server
+2. Sends the repo to the README harness
+3. Streams progress (which agent is running, tool calls, feedback)
+4. Prints the final README to stdout (or saves to file)
+"""
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+
+
+def create_session(base_url: str) -> str:
+    """Create a new session and return its ID."""
+    url = f"{base_url}/apps/app/users/cli_user/sessions"
+    req = urllib.request.Request(
+        url,
+        data=b"{}",
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as resp:
+        data = json.loads(resp.read())
+        return data["id"]
+
+
+def run_harness(base_url: str, session_id: str, repo: str):
+    """Send repo to the harness and stream progress. Returns final README."""
+    url = f"{base_url}/run_sse"
+    payload = json.dumps(
+        {
+            "app_name": "app",
+            "user_id": "cli_user",
+            "session_id": session_id,
+            "new_message": {
+                "role": "user",
+                "parts": [{"text": f"Improve the README for {repo}"}],
+            },
+            "streaming": False,
+        }
+    ).encode()
+
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    final_readme = ""
+    current_agent = ""
+    iteration = 0
+
+    with urllib.request.urlopen(req, timeout=300) as resp:
+        for raw_line in resp:
+            line = raw_line.decode("utf-8").strip()
+            if not line or line.startswith(":"):
+                continue
+            if not line.startswith("data: "):
+                continue
+
+            data = line[6:]
+            try:
+                event = json.loads(data)
+            except json.JSONDecodeError:
+                continue
+
+            content = event.get("content", {})
+            author = content.get("author", event.get("author", ""))
+            parts = content.get("parts", [])
+
+            # Track agent transitions
+            if author and author != current_agent:
+                current_agent = author
+                if author == "codebase_analyzer":
+                    log("STAGE 1", "Analyzing codebase via GitHub MCP...")
+                elif author == "readme_writer":
+                    iteration += 1
+                    if iteration == 1:
+                        log("STAGE 2", "Generating README (pass 1)...")
+                    else:
+                        log("REFINE", f"Improving README (pass {iteration})...")
+                elif author == "readme_critic":
+                    log("REVIEW", f"Critic reviewing (pass {iteration})...")
+
+            for part in parts:
+                if "functionCall" in part:
+                    fc = part["functionCall"]
+                    name = fc["name"]
+                    args = fc.get("args", {})
+
+                    if name == "exit_loop":
+                        log("APPROVED", "Critic approved the README!")
+                    elif name == "get_file_contents":
+                        path = args.get("path", "/")
+                        log(
+                            "  FETCH",
+                            f"{args.get('owner', '')}/{args.get('repo', '')}/{path}",
+                        )
+                    elif name == "search_code":
+                        log("  SEARCH", f"query: {args.get('query', '')[:60]}")
+                    elif name == "load_skill":
+                        log("  SKILL", f"Loading: {args.get('name', '')}")
+                    elif name == "load_skill_resource":
+                        log("  SKILL", f"Reading: {args.get('path', '')}")
+                    else:
+                        log("  TOOL", f"{name}")
+
+                elif "text" in part:
+                    text = part["text"]
+                    if author == "codebase_analyzer":
+                        # Show first line of analysis
+                        first_line = text.strip().split("\n")[0][:120]
+                        log("ANALYSIS", first_line)
+                    elif author == "readme_writer":
+                        # Capture the README output
+                        final_readme = text
+                        lines = text.strip().split("\n")
+                        log("DRAFT", f"{len(lines)} lines generated")
+                    elif author == "readme_critic":
+                        if "exit_loop" not in text.lower() and len(text) > 30:
+                            # Show first line of feedback
+                            first_line = text.strip().split("\n")[0][:120]
+                            log("FEEDBACK", first_line)
+
+    return final_readme
+
+
+def log(tag: str, message: str):
+    """Print a formatted progress line to stderr."""
+    # Color codes for terminal
+    colors = {
+        "STAGE 1": "\033[36m",  # cyan
+        "STAGE 2": "\033[33m",  # yellow
+        "REFINE": "\033[33m",  # yellow
+        "REVIEW": "\033[35m",  # magenta
+        "APPROVED": "\033[32m",  # green
+        "ANALYSIS": "\033[36m",  # cyan
+        "DRAFT": "\033[33m",  # yellow
+        "FEEDBACK": "\033[31m",  # red
+        "  FETCH": "\033[90m",  # gray
+        "  SEARCH": "\033[90m",  # gray
+        "  SKILL": "\033[90m",  # gray
+        "  TOOL": "\033[90m",  # gray
+    }
+    reset = "\033[0m"
+    color = colors.get(tag, "")
+    print(f"{color}[{tag:>10}]{reset} {message}", file=sys.stderr)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Call the README harness")
+    parser.add_argument("repo", help="GitHub repo in owner/repo format")
+    parser.add_argument(
+        "--host", default="http://localhost:8000", help="api_server URL"
+    )
+    parser.add_argument("--save", help="Save README to file instead of stdout")
+    args = parser.parse_args()
+
+    print(f"\033[1m{'=' * 60}\033[0m", file=sys.stderr)
+    print(f"\033[1m README Harness — {args.repo}\033[0m", file=sys.stderr)
+    print(f"\033[1m{'=' * 60}\033[0m", file=sys.stderr)
+
+    try:
+        session_id = create_session(args.host)
+        log("SESSION", f"Created: {session_id[:8]}...")
+    except urllib.error.URLError:
+        print(
+            "ERROR: Cannot connect to api_server. Is it running?",
+            file=sys.stderr,
+        )
+        print("Start it with: adk api_server . --port 8000", file=sys.stderr)
+        sys.exit(1)
+
+    readme = run_harness(args.host, session_id, args.repo)
+
+    print(f"\033[1m{'=' * 60}\033[0m", file=sys.stderr)
+
+    if args.save:
+        with open(args.save, "w") as f:
+            f.write(readme)
+        log("SAVED", f"README written to {args.save}")
+    else:
+        # Print README to stdout (progress went to stderr)
+        print(readme)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/agents/readme-harness/app/skills/readme-conventions/SKILL.md
+++ b/python/agents/readme-harness/app/skills/readme-conventions/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: readme-conventions
+description: >
+  Quality conventions for writing developer-focused README files.
+  Covers required sections, structure, and quality criteria.
+  Load the checklist reference for section-by-section requirements.
+---
+
+# README Conventions
+
+## When to Use
+
+Load this skill when generating or improving a README.md file for a code repository.
+
+## Process
+
+1. Read `references/checklist.md` for the full section-by-section quality checklist.
+2. Follow the section order defined in the checklist.
+3. Write from the perspective of a developer who just discovered this repo
+   and wants to clone, install, and use it within 5 minutes.
+
+## Rules
+
+1. Start with the project name as an H1 heading, followed by a one-sentence description.
+2. Every section from the checklist must be present. If a section does not apply, include it with a brief note explaining why.
+3. Installation instructions must include exact commands (not placeholders).
+4. Usage examples must show real code or CLI commands, not abstract descriptions.
+5. Keep the total README under 500 lines. Put detailed API docs in separate files if needed.
+6. Do not use badges unless the project already has CI/CD configured.
+7. Do not include a table of contents for READMEs under 200 lines.

--- a/python/agents/readme-harness/app/skills/readme-conventions/references/checklist.md
+++ b/python/agents/readme-harness/app/skills/readme-conventions/references/checklist.md
@@ -1,0 +1,57 @@
+# README Quality Checklist
+
+Each section below is required. The README critic validates against this list.
+
+## 1. Title and Description
+
+- H1 heading with the project name
+- One-sentence description of what the project does
+- Who it is for (target audience)
+
+## 2. Prerequisites
+
+- Runtime requirements (Python version, Node.js, etc.)
+- System dependencies (databases, external services)
+- Required accounts or API keys
+
+## 3. Installation
+
+- Clone command
+- Dependency installation command
+- Any build or compilation steps
+- Must be copy-pasteable (no placeholders like "your-path-here")
+
+## 4. Configuration
+
+- Environment variables with descriptions
+- Configuration files and their format
+- Example .env or config file content
+
+## 5. Usage
+
+- At least one complete example (code snippet or CLI command)
+- Expected output or result
+- Common use cases (2-3 examples if applicable)
+
+## 6. Project Structure
+
+- Brief description of key directories and files
+- Where to find the main entry point
+- Where configuration lives
+
+## 7. API / Key Features
+
+- Main capabilities or endpoints listed
+- Brief description of each
+- Link to detailed docs if they exist
+
+## 8. Contributing
+
+- How to set up a development environment
+- How to run tests
+- How to submit changes (PR process or contact)
+
+## 9. License
+
+- License type stated
+- Link to LICENSE file if it exists

--- a/python/agents/readme-harness/pyproject.toml
+++ b/python/agents/readme-harness/pyproject.toml
@@ -1,0 +1,40 @@
+[project]
+name = "readme-harness"
+version = "0.1.0"
+description = "A README improvement harness that fetches a GitHub repo via MCP, generates a README against a quality checklist using SkillToolset, and refines in a LoopAgent until a critic approves."
+authors = [{ name = "Lavi Nigam", email = "nicklavi@google.com" }]
+license = {text = "Apache License 2.0"}
+readme = "README.md"
+requires-python = ">=3.11"
+
+dependencies = [
+    "google-adk>=1.25.0,<2.0.0",
+    "mcp>=1.0.0,<2.0.0",
+]
+
+[dependency-groups]
+dev = [
+    "google-adk[eval]>=1.25.0",
+    "pytest-asyncio>=0.26.0",
+    "pytest>=8.3.5",
+]
+
+[tool.ruff]
+extend = "../../../pyproject.toml"
+
+[tool.ruff.lint]
+ignore = ["C901"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
+"**/call_harness.py" = ["PLR0912", "PLR0915", "PLR2004"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["app"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["app"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary
- Adds a new sample agent (`readme-harness`) that demonstrates a multi-agent workflow pipeline
- Uses **SequentialAgent** (two-stage pipeline) + **LoopAgent** (iterative refinement) + **McpToolset** (GitHub MCP) + **SkillToolset** (README conventions) + **exit_loop** (critic approval)
- Includes a CLI helper script (`call_harness.py`) for programmatic use via `adk api_server`
- Includes a portable CLI skill (`cli_harness/`) compatible with Claude Code and Gemini CLI
- Adds entry to the agents README table

## Test plan
- [x] Ruff lint and format checks pass
- [x] Codespell passes
- [x] Agent structure follows repo conventions (`pyproject.toml` with hatchling, `.env.example`, `app/` package)
- [x] Local testing with `adk web` (requires GitHub PAT and Node.js/npx)