### PR TITLE
docs(go): fix setup command in README

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -54,7 +54,7 @@ Follow these steps to set up and run the sample agents:
     *   Choose an agent from the `agents/` directory.
     *   Navigate into that agent's specific directory (e.g., `cd agents/llm-auditor`).
     *   Follow the instructions in *that agent's* `README.md` file for specific
-        setup (like installing dependencies via `poetry install`) and running
+        setup (like installing dependencies via `go mod tidy`) and running
         the agent.
     *   Browse the folders in this repository. Each agent and tool have its own
         `README.md` file with detailed instructions.


### PR DESCRIPTION
# Description

- Replace the incorrect Python-specific poetry install example in the `Go` README

- Use `go mod tidy`, which matches the sample’s actual setup flow
