### PR TITLE
Fix broken adk-python references in evaluation notebooks

### DIFF
--- a/python/notebooks/evaluation/evaluation_criteria_in_adk.ipynb
+++ b/python/notebooks/evaluation/evaluation_criteria_in_adk.ipynb
@@ -222,9 +222,9 @@
    ],
    "source": [
     "# @title Download HelloWorld Agent From ADK Github Repo\n",
-    "AGENT_BASE_PATH = \"adk-python/contributing/samples/hello_world\"\n",
+    "AGENT_BASE_PATH = \"adk-python/contributing/samples/core/hello_world\"\n",
     "\n",
-    "!git clone https://github.com/google/adk-python/\n",
+    "!git clone -b v2.1.0 https://github.com/google/adk-python/\n",
     "!ls {AGENT_BASE_PATH}"
    ]
   },

--- a/python/notebooks/evaluation/user_simulation_in_adk_evals.ipynb
+++ b/python/notebooks/evaluation/user_simulation_in_adk_evals.ipynb
@@ -180,8 +180,8 @@
    "source": [
     "# @title Download HelloWorld Agent From ADK Github Repo\n",
     "\n",
-    "!git clone https://github.com/google/adk-python/\n",
-    "AGENT_BASE_PATH = \"adk-python/contributing/samples/hello_world\"\n",
+    "!git clone -b v2.1.0 https://github.com/google/adk-python/\n",
+    "AGENT_BASE_PATH = \"adk-python/contributing/samples/core/hello_world\"\n",
     "!ls {AGENT_BASE_PATH}"
    ]
   },


### PR DESCRIPTION
Pins adk-python git clone to v2.1.0 tag and updates AGENT_BASE_PATH to the correct path structure 'contributing/samples/core/hello_world' to resolve broken paths.