### PR TITLE
feat(customer-service-typescript): update typescript prompt tool names

### DIFF
--- a/typescript/agents/customer_service/customer_service/prompts.ts
+++ b/typescript/agents/customer_service/customer_service/prompts.ts
@@ -69,18 +69,18 @@ Always use conversation context/state or tools to get information. Prefer tools 
 **Tools:**
 You have access to the following tools to assist you:
 
-* "send_call_companion_link": Sends a link for video connection. Use this tool to start live streaming with the user. When user agrees with you to share video, use this tool to start the process 
-* "approve_discount": Approves a discount (within pre-defined limits).
-* "sync_ask_for_approval": Requests discount approval from a manager (synchronous version).
-* "update_salesforce_crm": Updates customer records in Salesforce after the customer has completed a purchase.
-* "access_cart_information": Retrieves the customer's cart contents. Use this to check customers cart contents or as a check before related operations
-* "modify_cart": Updates the customer's cart. before modifying a cart first access_cart_information to see what is already in the cart
-* "get_product_recommendations": Suggests suitable products for a given plant type. i.e petunias. before recomending a product access_cart_information so you do not recommend something already in cart. if the product is in cart say you already have that
-* "check_product_availability": Checks product stock.
-* "schedule_planting_service": Books a planting service appointment.
-* "get_available_planting_times": Retrieves available time slots.
-* "send_care_instructions": Sends plant care information.
-* "generate_qr_code": Creates a discount QR code 
+* "sendCallCompanionLinkTool": Sends a link for video connection. Use this tool to start live streaming with the user. When user agrees with you to share video, use this tool to start the process 
+* "approveDiscountTool": Approves a discount (within pre-defined limits).
+* "syncAskForApprovalTool": Requests discount approval from a manager (synchronous version).
+* "updateSalesforceCrmTool": Updates customer records in Salesforce after the customer has completed a purchase.
+* "accessCartInformationTool": Retrieves the customer's cart contents. Use this to check customers cart contents or as a check before related operations
+* "modifyCartTool": Updates the customer's cart. before modifying a cart first accessCartInformationTool to see what is already in the cart
+* "getProductRecommendationsTool": Suggests suitable products for a given plant type. i.e petunias. before recomending a product accessCartInformationTool so you do not recommend something already in cart. if the product is in cart say you already have that
+* "checkProductAvailabilityTool": Checks product stock.
+* "schedulePlantingServiceTool": Books a planting service appointment.
+* "getAvailablePlantingTimesTool": Retrieves available time slots.
+* "sendCareInstructionsTool": Sends plant care information.
+* "generateQrCodeTool": Creates a discount QR code 
 
 **Constraints:**
 


### PR DESCRIPTION
Summary
Updates the tool name references in the system prompt (INSTRUCTION) for the TypeScript customer service agent to match the actual registered tool names used in the codebase.

Problem
The prompt was referencing tools using snake_case naming (e.g., send_call_companion_link, modify_cart), which did not match the camelCase + Tool suffix naming convention used by the actual TypeScript tool definitions (e.g., sendCallCompanionLinkTool, modifyCartTool).

Changes
Updated all tool name references in the INSTRUCTION prompt from snake_case to camelCase + Tool suffix to align with the actual TypeScript tool implementations.

File: prompts.ts