### PR TITLE
fix(customer-service): apply lowercase_value in before_tool callback

### DIFF
--- a/python/agents/customer-service/customer_service/shared_libraries/callbacks.py
+++ b/python/agents/customer-service/customer_service/shared_libraries/callbacks.py
@@ -126,24 +126,29 @@ def validate_customer_id(
 
 
 def lowercase_value(value):
-    """Make dictionary lowercase"""
+    """Recursively lowercase string values in nested structures."""
     if isinstance(value, dict):
-        return (dict(k, lowercase_value(v)) for k, v in value.items())
-    elif isinstance(value, str):
+        return {k: lowercase_value(v) for k, v in value.items()}
+    if isinstance(value, str):
         return value.lower()
-    elif isinstance(value, (list, set, tuple)):
-        tp = type(value)
-        return tp(lowercase_value(i) for i in value)
-    else:
-        return value
+    if isinstance(value, list):
+        return [lowercase_value(i) for i in value]
+    if isinstance(value, tuple):
+        return tuple(lowercase_value(i) for i in value)
+    if isinstance(value, set):
+        return {lowercase_value(i) for i in value}
+    return value
 
 
 # Callback Methods
 def before_tool(
     tool: BaseTool, args: dict[str, Any], tool_context: CallbackContext
 ):
-    # i make sure all values that the agent is sending to tools are lowercase
-    lowercase_value(args)
+    # Make sure all string values the agent sends to tools are lowercase.
+    normalized_args = lowercase_value(args)
+    if isinstance(normalized_args, dict):
+        args.clear()
+        args.update(normalized_args)
 
     # Several tools require customer_id as input. We don't want to rely
     # solely on the model picking the right customer id. We validate it.

--- a/python/agents/customer-service/tests/unit/test_callbacks.py
+++ b/python/agents/customer-service/tests/unit/test_callbacks.py
@@ -1,0 +1,42 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from customer_service.shared_libraries.callbacks import lowercase_value
+
+
+def test_lowercase_value_recurses_through_nested_dicts():
+    value = {
+        "name": "JOHN DOE",
+        "email": "John@Example.COM",
+        "nested": {"City": "NEW YORK"},
+    }
+
+    assert lowercase_value(value) == {
+        "name": "john doe",
+        "email": "john@example.com",
+        "nested": {"city": "new york"},
+    }
+
+
+def test_lowercase_value_handles_lists_and_tuples():
+    assert lowercase_value(["ABC", {"Key": "Value"}]) == [
+        "abc",
+        {"key": "value"},
+    ]
+    assert lowercase_value(("ABC", "DEF")) == ("abc", "def")
+
+
+def test_lowercase_value_leaves_non_string_scalars_unchanged():
+    assert lowercase_value(42) == 42
+    assert lowercase_value(True) is True


### PR DESCRIPTION
## Summary

Fixes `lowercase_value()` in the customer-service sample so `before_tool` actually normalizes tool arguments.

## Problems fixed

1. **Return value discarded** — `before_tool` called `lowercase_value(args)` without using the result, so strings were never lowercased.
2. **`TypeError` in dict branch** — `dict(k, lowercase_value(v))` is invalid; replaced with a dict comprehension.

## Approach

- `lowercase_value` now returns a fully normalized structure (dict / list / tuple / set / str).
- `before_tool` clears and updates the mutable `args` dict in place so downstream validation still sees the same object.

## Tests

- Added `tests/unit/test_callbacks.py` covering nested dicts, sequences, and non-string scalars.

Fixes #2081

cc @anifort for customer-service sample review