### PR TITLE
fix(academic-research): keep Agent Engine SDK versions in sync

### DIFF
--- a/python/agents/academic-research/README.md
+++ b/python/agents/academic-research/README.md
@@ -115,7 +115,7 @@ The `adk web` command starts a local server and prints a URL. Open it, select **
 who are you
 ```
 
-Sampled responses of these requrests are shown below in the [Example
+Sampled responses of these requests are shown below in the [Example
 Interaction](#example-interaction) section.
 
 ```
@@ -374,6 +374,11 @@ commands:
 uv sync --group deployment
 uv run deployment/deploy.py --create
 ```
+
+The deployment script pins the remote ADK and Vertex AI SDK versions to the
+versions installed in the local `uv` environment. Run `uv sync` before
+deploying so the serialized agent and Agent Engine runtime use compatible
+framework versions.
 
 When the deployment finishes, it will print a line like this:
 

--- a/python/agents/academic-research/deployment/deploy.py
+++ b/python/agents/academic-research/deployment/deploy.py
@@ -19,6 +19,7 @@ import os
 import vertexai
 from absl import app, flags
 from dotenv import load_dotenv
+from runtime_requirements import get_deployment_requirements
 from vertexai import agent_engines
 from vertexai.preview.reasoning_engines import AdkApp
 
@@ -43,13 +44,7 @@ def create() -> None:
     remote_agent = agent_engines.create(
         adk_app,
         display_name=root_agent.name,
-        requirements=[
-            "google-adk (>=0.0.2)",
-            "google-cloud-aiplatform[agent_engines] (>=1.91.0,!=1.92.0)",
-            "google-genai (>=1.5.0,<2.0.0)",
-            "pydantic (>=2.10.6,<3.0.0)",
-            "absl-py (>=2.2.1,<3.0.0)",
-        ],
+        requirements=get_deployment_requirements(),
         #        extra_packages=[""],
     )
     print(f"Created remote agent: {remote_agent.resource_name}")

--- a/python/agents/academic-research/deployment/runtime_requirements.py
+++ b/python/agents/academic-research/deployment/runtime_requirements.py
@@ -1,0 +1,28 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build reproducible Agent Engine requirements for this recipe."""
+
+from importlib.metadata import version
+
+
+def get_deployment_requirements() -> list[str]:
+    """Pin the remote ADK runtime to the locally tested SDK versions."""
+    aiplatform_version = version("google-cloud-aiplatform")
+    adk_version = version("google-adk")
+
+    return [
+        f"google-cloud-aiplatform[agent_engines,adk]=={aiplatform_version}",
+        f"google-adk=={adk_version}",
+    ]

--- a/python/agents/academic-research/tests/test_deployment_requirements.py
+++ b/python/agents/academic-research/tests/test_deployment_requirements.py
@@ -1,0 +1,39 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Agent Engine deployment requirements."""
+
+import pytest
+
+from deployment import runtime_requirements
+
+
+def test_deployment_requirements_pin_local_framework_versions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The remote runtime should use the locally installed SDK versions."""
+    installed_versions = {
+        "google-cloud-aiplatform": "1.143.0",
+        "google-adk": "1.27.4",
+    }
+    monkeypatch.setattr(
+        runtime_requirements,
+        "version",
+        installed_versions.__getitem__,
+    )
+
+    assert runtime_requirements.get_deployment_requirements() == [
+        "google-cloud-aiplatform[agent_engines,adk]==1.143.0",
+        "google-adk==1.27.4",
+    ]


### PR DESCRIPTION
Closes #1223.

## Summary

The academic-research deployment script now pins the remote Agent Engine runtime to the locally installed `google-cloud-aiplatform` and `google-adk` versions. The Vertex AI requirement also includes the `adk` extra so the deployment receives the compatible framework integration.

This prevents the serialized `AdkApp` from being deployed with a different ADK API surface, which caused the `canonical_on_model_error_callbacks` type error reported in the issue.

The README now explains the version-parity requirement, and the deployment requirement builder has a credential-free unit test.

## Tests

- `.venv/bin/pytest -q tests/test_deployment_requirements.py` — 1 passed
- `.venv/bin/ruff check deployment/runtime_requirements.py deployment/deploy.py tests/test_deployment_requirements.py`
- `.venv/bin/ruff format --check deployment/runtime_requirements.py deployment/deploy.py tests/test_deployment_requirements.py`
- `.venv/bin/mypy deployment/runtime_requirements.py tests/test_deployment_requirements.py`
- `.venv/bin/codespell README.md deployment/deploy.py deployment/runtime_requirements.py tests/test_deployment_requirements.py`
- `.venv/bin/python -m compileall -q deployment/runtime_requirements.py deployment/deploy.py tests/test_deployment_requirements.py`

With the checked-in lock file, the generated requirements are:

```text
google-cloud-aiplatform[agent_engines,adk]==1.143.0
google-adk==1.27.4
```

A live Agent Engine deployment was not run because it requires a configured GCP project, storage bucket, credentials, and billable cloud resources.
