### PR TITLE
docs: fix broken links in retail and android fun-facts READMEs

### DIFF
--- a/android/agents/fun-facts/README.md
+++ b/android/agents/fun-facts/README.md
@@ -8,7 +8,7 @@ facts about any topic, with a Jetpack Compose chat interface.
 
 The Fun Facts Agent is a single-agent sample designed to demonstrate how to
 integrate ADK Kotlin into a native Android application. It wraps the same
-fun-facts agent from the [Kotlin samples](../../kotlin/agents/fun-facts/) in a
+fun-facts agent from the [Kotlin samples](../../../kotlin/agents/fun-facts/) in a
 Compose-based chat UI, using `InMemoryRunner` inside a ViewModel to manage
 agent interactions.
 

--- a/python/agents/retail-ai-location-strategy/README.md
+++ b/python/agents/retail-ai-location-strategy/README.md
@@ -423,4 +423,4 @@ Users are solely responsible for any further development, testing, security hard
 
 ## License
 
-Apache 2.0 - See [LICENSE](LICENSE) for details.
+Apache 2.0 - See [LICENSE](../../../LICENSE) for details.


### PR DESCRIPTION
Two broken links (mechanical link audit; targets verified to exist):

- `python/agents/retail-ai-location-strategy/README.md` — `[LICENSE](LICENSE)` resolves inside the agent directory, which has no LICENSE file; the license lives at the repo root → `../../../LICENSE`
- `android/agents/fun-facts/README.md` — `[Kotlin samples](../../kotlin/agents/fun-facts/)` resolves to `android/kotlin/...`; the Kotlin sample lives at the repo root → `../../../kotlin/agents/fun-facts/`

Also found but **not** fixed (no verifiable successor): `python/agents/sdlc-task-planner` and `sdlc-technical-designer` READMEs link `sdlc_agents_workflow.md`, which doesn't exist anywhere in the repo.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)